### PR TITLE
Adjust for changes in VHOST_USER_SET_MEM_TABLE

### DIFF
--- a/vhost_client.c
+++ b/vhost_client.c
@@ -51,6 +51,7 @@ VhostClient* new_vhost_client(const char* path)
         vhost_client->memory.regions[idx].guest_phys_addr = (uintptr_t) shm;
         vhost_client->memory.regions[idx].memory_size = vhost_client->page_size;
         vhost_client->memory.regions[idx].userspace_addr = (uintptr_t) shm;
+        vhost_client->memory.regions[idx].mmap_offset = 0;
     }
 
     // init vrings on the shm (through memory regions)

--- a/vhost_server.c
+++ b/vhost_server.c
@@ -164,6 +164,7 @@ static int _set_mem_table(VhostServer* vhost_server, ServerMsg* msg)
 
             region->mmap_addr =
                     (uintptr_t) init_shm_from_fd(msg->fds[idx], region->memory_size);
+            region->mmap_addr += msg->msg.memory.regions[idx].mmap_offset;
 
             vhost_server->memory.nregions++;
         }

--- a/vhost_user.h
+++ b/vhost_user.h
@@ -19,6 +19,7 @@ typedef struct VhostUserMemoryRegion {
     uint64_t guest_phys_addr;
     uint64_t memory_size;
     uint64_t userspace_addr;
+    uint64_t mmap_offset;
 } VhostUserMemoryRegion;
 
 typedef struct VhostUserMemory {


### PR DESCRIPTION
VhostUserMemoryRegion, used for VHOST_USER_SET_MEM_TABLE, gained a new
field: mmap_offset. Add it and adjust both server and client
accordingly. This re-enables the use of the server with QEMU for testing
purposes.

Signed-off-by: Jan Kiszka jan.kiszka@siemens.com
